### PR TITLE
Change figcaption to h3 and figure to img

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,14 +19,11 @@
             <!-- hacksaw brushes -->
             <section>
                 <h2 id="green">Brushes</h2>
-                
-                <figure>
+                <img>
                     <img src="./resources/images/hacksaw.jpeg" 
                     alt="hacksaw brushes">
-                
-                    <figcaption>Hacksaw Brushes</figcaption>
-                </figure>
-                
+                </img>
+                <h3>Hacksaw Brushes</h3>
                 <p>Made of the highest quality oak, Hacksaw brushes are known for their weight and ability to hold paint in large amounts. Available in different sizes. 
                     <span>Starting at $3.00 / brush.</span>
                 </p>


### PR DESCRIPTION
I noticed that in your version, the images as well as the subheadlines are not quite left aligned.

Your version:
![image](https://user-images.githubusercontent.com/111209756/190773655-034f7a4b-6c4e-4226-a98d-162bfdc6d6a6.png)

Specs:
![image](https://user-images.githubusercontent.com/111209756/190775056-5d1e0d7a-462f-4711-99cf-2bc4669ec009.png)

1. I changed the figure tag to the img tag. That seems to align the image more left and is therefore closer to the specs, although figure seems to be better in terms of semantic HTML.

2. I changed the figcaption to a h3 headline. It seems like it is meant to be a headline for the text below and not a caption for the image above.

I only did that for the first section (Hacksaw Brushes)